### PR TITLE
Ci cache gobuild

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,8 @@ steps:
   volumes:
   - name: gomod
     path: /go/pkg/mod
+  - name: gocache
+    path: /root/.cache/go-build
   commands:
     - make test
 
@@ -16,3 +18,6 @@ volumes:
   - name: gomod
     host: 
       path: /tmp/drone/zaidan/gomod
+  - name: gocache
+    host:
+      path: /tmp/drone/zaidan/gocache


### PR DESCRIPTION
Adding caching via volumes, this reduces the build time and testing in Go to a couple of seconds when go code hasn't changed. Trying the same approach on kosu-monorepo with `node_modules` https://github.com/ParadigmFoundation/kosu-monorepo/pull/387