### PR TITLE
project: add gocache to lint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,10 @@ steps:
   image: golangci/golangci-lint:v1.21.0
   depends_on: ["clone"]
   volumes:
+  - name: gomod
+    path: /go/pkg/mod
+  - name: gocache
+    path: /root/.cache/go-build
   - name: golint
     path: /root/.cache/golangci-lint
   commands:


### PR DESCRIPTION
Using go cache here improved the speed of the linter from `~1:20` to `~0:10`